### PR TITLE
Use release version of Quarto

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,8 +18,6 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: quarto-dev/quarto-actions/setup@v2
-        with:
-          version: pre-release
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4


### PR DESCRIPTION
This tests if the pre-release version of Quarto (1.3.x) is the cause of some current build problems.