### PR TITLE
Support R Shiny apps

### DIFF
--- a/_extensions/quarto-ext/shinylive/shinylive.lua
+++ b/_extensions/quarto-ext/shinylive/shinylive.lua
@@ -65,7 +65,10 @@ end
 return {
   {
     CodeBlock = function(el)
-      if el.attr and el.attr.classes:includes("{shinylive-python}") then
+      if el.attr and (
+        el.attr.classes:includes("{shinylive-python}")
+        or el.attr.classes:includes("{shinylive-r}")
+     ) then
         ensureShinyliveSetup()
 
         -- Convert code block to JSON string in the same format as app.json.
@@ -90,8 +93,15 @@ return {
           quarto.doc.attach_to_dependency("shinylive", dep)
         end
 
-        el.attr.classes = pandoc.List()
-        el.attr.classes:insert("shinylive-python")
+        if el.attr.classes:includes("{shinylive-python}") then
+          el.attributes.engine = "python"
+          el.attr.classes = pandoc.List()
+          el.attr.classes:insert("shinylive-python")
+        elseif el.attr.classes:includes("{shinylive-r}") then
+          el.attributes.engine = "r"
+          el.attr.classes = pandoc.List()
+          el.attr.classes:insert("shinylive-r")
+        end
         return el
       end
     end


### PR DESCRIPTION
This tweaks the `Codeblock` handling so that `{shinylive-r}` type blocks are detected and included in processing.

With this change, `el.attributes.engine` is set to `"python"` or `"r"`, depending on the type of Shiny code block. With the changes in the PR at rstudio/shinylive#51, Shinylive is able to read and use this data-attribute to embed the Shiny app into the page using the correct Wasm engine.

Before this can work, the assets installed with `shinylive assets` must be a version of Shinylive with rstudio/shinylive#51 merged. I've been using `shinylive assets install-from-local --source ../shinylive/build/` to install a copy of the assets from my local Shinylive fork.

Demo: https://georgestagg.github.io/quarto-shinylive-demo/

Note: loading webR's Shiny takes a fair while longer than Pyodide's Shiny for Python. See discussion in rstudio/shinylive#51 for my initial thoughts about how to deal with this in the future.