### PR TITLE
feat(lua): When possible, use Quarto Lua API from Quarto 1.5.32+ to get the path to quarto

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 jobs:
   build:

--- a/_extensions/quarto-ext/shinylive/_extension.yml
+++ b/_extensions/quarto-ext/shinylive/_extension.yml
@@ -1,8 +1,8 @@
 name: shinylive
 title: Embedded Shinylive applications
 author: Winston Chang
-version: 0.1.0
-quarto-required: ">=1.2.198"
+version: 0.2.0
+quarto-required: ">= 1.5.32"
 contributes:
   filters:
     - shinylive.lua

--- a/_extensions/quarto-ext/shinylive/_extension.yml
+++ b/_extensions/quarto-ext/shinylive/_extension.yml
@@ -2,7 +2,7 @@ name: shinylive
 title: Embedded Shinylive applications
 author: Winston Chang
 version: 0.2.0
-quarto-required: ">= 1.5.32"
+quarto-required: ">= 1.2.198"
 contributes:
   filters:
     - shinylive.lua

--- a/_extensions/quarto-ext/shinylive/shinylive.lua
+++ b/_extensions/quarto-ext/shinylive/shinylive.lua
@@ -1,4 +1,7 @@
 -- Notes:
+-- * 2024/05/03 - Christophe:
+--   `quarto run` needs to be called using the same quarto CLI that called the extension.
+--   This is done by using `quarto.cli_path` from Quarto 1.5 Lua API.
 -- * 2023/10/04 - Barret:
 --   Always use `callShinyLive()` to call a shinylive extension.
 --   `callPythonShinyLive()` and `callRShinyLive()` should not be used directly.
@@ -415,7 +418,8 @@ return {
 
       -- Convert code block to JSON string in the same format as app.json.
       local parsedCodeblockJson = pandoc.pipe(
-        "quarto",
+        -- Use quarto binary that called this extension 
+        quarto.config.cli_path(),
         { "run", codeblockScript, language },
         el.text
       )

--- a/_extensions/quarto-ext/shinylive/shinylive.lua
+++ b/_extensions/quarto-ext/shinylive/shinylive.lua
@@ -1,7 +1,4 @@
 -- Notes:
--- * 2024/05/03 - Christophe:
---   `quarto run` needs to be called using the same quarto CLI that called the extension.
---   This is done by using `quarto.cli_path` from Quarto 1.5 Lua API.
 -- * 2023/10/04 - Barret:
 --   Always use `callShinyLive()` to call a shinylive extension.
 --   `callPythonShinyLive()` and `callRShinyLive()` should not be used directly.
@@ -396,6 +393,16 @@ function getShinyliveBaseDeps(language)
   return deps
 end
 
+-- Legacy quarto cli location
+quarto_cli_path = "quarto"
+if quarto.config ~= nil and quarto.config.cli_path ~= nil then
+  -- * 2024/05/03 - Christophe:
+  --   `quarto run` needs to be called using the same quarto CLI that called the extension.
+  --   This is done by using `quarto.config.cli_path()` from Quarto 1.5 Lua API.
+  --   https://github.com/quarto-dev/quarto-cli/pull/9576
+  quarto_cli_path = quarto.config.cli_path()
+end
+
 return {
   {
     CodeBlock = function(el)
@@ -418,8 +425,7 @@ return {
 
       -- Convert code block to JSON string in the same format as app.json.
       local parsedCodeblockJson = pandoc.pipe(
-        -- Use quarto binary that called this extension 
-        quarto.config.cli_path(),
+        quarto_cli_path,
         { "run", codeblockScript, language },
         el.text
       )


### PR DESCRIPTION
Otherwise, this extension fails to call `quarto run` on environment where `quarto` is not in the PATH. Though, even if in the PATH, it could be calling another quarto CLI that the one used to run the extension

closes #50 

@schloerke 

this is a companion to 
- https://github.com/quarto-dev/quarto-cli/pull/9576

and should be merged only after, and when Quarto 1.5 will be out. Hence the draft PR.

There is also a way to have another fix for #50 by directly handling this specific CLI path resolution so that it works also with older versions
