### PR TITLE
feat: Add warning to code chunk about `embed-resources`

### DIFF
--- a/_extensions/quarto-ext/shinylive/shinylive.lua
+++ b/_extensions/quarto-ext/shinylive/shinylive.lua
@@ -458,6 +458,13 @@ return {
         el.attr.classes = pandoc.List()
         el.attr.classes:insert("shinylive-r")
       end
+      
+      el.text = 
+        "#| '!! shinylive warning !!': |\n"..
+        "#|   shinylive does not work in self-contained HTML documents.\n" .. 
+        "#|   Please set `embed-resources: false` in your metadata.\n" ..
+        el.text
+      
       return el
     end
   }


### PR DESCRIPTION
For #12

When shinylive is used with `embed-resources: true`, the original code chunk is shown in full instead of the shinylive app. 

So we can add some warning code to the top of the code chunk that only shows up when shinylive fails to load. The top of the code chunk always contains the chunk options, so we need to use the same syntax:

```
#| '!! shinylive warning !!': |
#|   shinylive does not work in self-contained HTML documents.
#|   Please set `embed-resources: false` in your metadata.
```

Hopefully this gives enough information to the person with the broken output to figure out what's going wrong.

<details>
<summary>Test Document</summary>

I put this in `_dev/issues/issue-12/issue-12.qmd`.

````markdown
---
title: "Shinylive with embed-resources: true"
format: 
  html:
    embed-resources: true
filters:
  - ../../../_extensions/quarto-ext/shinylive/shinylive.lua
---

```{shinylive-r}
#| standalone: true
#| components: [editor, viewer]
#| layout: vertical
#| viewerHeight: 400
## file: app.R
library(shiny)

ui <- fluidPage(
  titlePanel("Hello Shiny!")
)

server <- function(input, output) {

}

# Create Shiny app ----
shinyApp(ui = ui, server = server)
```
````

</details>

| `embed-resources: true` | `embed-resources: false` |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/cfaeb2f6-1a91-4d57-a46e-89aa0023ec3c) | ![image](https://github.com/user-attachments/assets/a2986a12-6d9f-49e2-af2f-521df51ba41d) | 